### PR TITLE
Update gtkmm modules to latest patch versions

### DIFF
--- a/gtkmm.yaml
+++ b/gtkmm.yaml
@@ -1,8 +1,8 @@
 name: gtkmm
 sources:
-  - sha256: ddfe42ed2458a20a34de252854bcf4b52d3f0c671c045f56b42aa27c7542d2fd
+  - sha256: 6d71091bcd1863133460d4188d04102810e9123de19706fb656b7bb915b4adc3
     type: archive
-    url: http://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.24/gtkmm-3.24.1.tar.xz
+    url: http://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.24/gtkmm-3.24.2.tar.xz
 config-opts:
   - --disable-documentation
 cleanup:
@@ -20,9 +20,9 @@ cleanup:
 modules:
   - name: sigc++
     sources:
-      - sha256: c9a25f26178c6cbb147f9904d8c533b5a5c5111a41ac2eb781eb734eea446003
+      - sha256: 0b68dfc6313c6cc90ac989c6d722a1bf0585ad13846e79746aa87cb265904786
         type: archive
-        url: http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.10/libsigc++-2.10.1.tar.xz
+        url: http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.10/libsigc++-2.10.3.tar.xz
     config-opts:
       - --disable-documentation
     cleanup:
@@ -33,9 +33,9 @@ modules:
 
   - name: glibmm
     sources:
-      - sha256: 6e5fe03bdf1e220eeffd543e017fd2fb15bcec9235f0ffd50674aff9362a85f0
+      - sha256: a75282e58d556d9b2bb44262b6f5fb76c824ac46a25a06f527108bec86b8d4ec
         type: archive
-        url: http://ftp.gnome.org/pub/GNOME/sources/glibmm/2.58/glibmm-2.58.1.tar.xz
+        url: http://ftp.gnome.org/pub/GNOME/sources/glibmm/2.64/glibmm-2.64.2.tar.xz
     config-opts:
       - --disable-documentation
     cleanup:
@@ -62,9 +62,9 @@ modules:
 
   - name: pangomm
     sources:
-      - sha256: ca6da067ff93a6445780c0b4b226eb84f484ab104b8391fb744a45cbc7edbf56
+      - sha256: 14bf04939930870d5cfa96860ed953ad2ce07c3fd8713add4a1bfe585589f40f
         type: archive
-        url: http://ftp.gnome.org/pub/GNOME/sources/pangomm/2.42/pangomm-2.42.0.tar.xz
+        url: http://ftp.gnome.org/pub/GNOME/sources/pangomm/2.42/pangomm-2.42.1.tar.xz
     config-opts:
       - --disable-documentation
     cleanup:


### PR DESCRIPTION
Also include glibmm 2.64, which is supported by runtime 20.08.