### PR TITLE
Give pavucontrol Manager level permissions under pipewire-pulse

### DIFF
--- a/org.pulseaudio.pavucontrol.yaml
+++ b/org.pulseaudio.pavucontrol.yaml
@@ -8,6 +8,7 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
   - --socket=pulseaudio
+  - --env=PULSE_PROP_media.category=Manager
 rename-desktop-file: pavucontrol.desktop
 rename-icon: multimedia-volume-control
 cleanup:


### PR DESCRIPTION
We do this by setting the pulseaudio/pipewire property media.category to Manager.