### PR TITLE
fix: add GPU acceleration permission

### DIFF
--- a/org.pulseaudio.pavucontrol.yaml
+++ b/org.pulseaudio.pavucontrol.yaml
@@ -8,6 +8,7 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
   - --socket=pulseaudio
+  - --device=dri
   - --env=PULSE_PROP_media.category=Manager
 rename-icon: multimedia-volume-control
 


### PR DESCRIPTION
Recently the app has stopped working for me on different devices with the error listed below. Manually granting the `device=dri` permission (for example, using flatseal) fixes the issue.

I don't know why the issue is showing up now as there are no changes in this app itself, but all other apps that work have this permission enabled (well, some of them have `device=all`).

Error:
```
❯ flatpak run org.pulseaudio.pavucontrol


MESA: error: Failed to query drm device.
libEGL warning: egl: failed to create dri2 screen
```
