### PR TITLE
gtkmm: Only track even-minor stable releases

### DIFF
--- a/gtkmm.json
+++ b/gtkmm.json
@@ -7,7 +7,9 @@
             "sha256": "2ee31c15479fc4d8e958b03c8b5fbbc8e17bc122c2a2f544497b4e05619e33ec",
             "x-checker-data": {
                 "type": "gnome",
-                "name": "gtkmm"
+                "name": "gtkmm",
+                "stable-only": true,
+                "version-scheme": "odd-minor-is-unstable"
             }
         }
     ],
@@ -39,7 +41,9 @@
                     "sha256": "c3d23b37dfd6e39f2e09f091b77b1541fbfa17c4f0b6bf5c89baef7229080e17",
                     "x-checker-data": {
                         "type": "gnome",
-                        "name": "libsigc++"
+                        "name": "libsigc++",
+                        "stable-only": true,
+                        "version-scheme": "odd-minor-is-unstable"
                     }
                 }
             ],
@@ -64,7 +68,9 @@
                     "sha256": "56ee5f51c8acfc0afdf46959316e4c8554cb50ed2b6bc5ce389d979cbb642509",
                     "x-checker-data": {
                         "type": "gnome",
-                        "name": "glibmm"
+                        "name": "glibmm",
+                        "stable-only": true,
+                        "version-scheme": "odd-minor-is-unstable"
                     }
                 }
             ],
@@ -116,7 +122,9 @@
                     "sha256": "539f5aa60e9bdc6b955bb448e2a62cc14562744df690258040fbb74bf885755d",
                     "x-checker-data": {
                         "type": "gnome",
-                        "name": "pangomm"
+                        "name": "pangomm",
+                        "stable-only": true,
+                        "version-scheme": "odd-minor-is-unstable"
                     }
                 }
             ],
@@ -137,7 +145,9 @@
                     "sha256": "6ec264eaa0c4de0adb7202c600170bde9a7fbe4d466bfbe940eaf7faaa6c5974",
                     "x-checker-data": {
                         "type": "gnome",
-                        "name": "atkmm"
+                        "name": "atkmm",
+                        "stable-only": true,
+                        "version-scheme": "odd-minor-is-unstable"
                     }
                 }
             ],


### PR DESCRIPTION
Back in March, f-e-d-c was changed to default to the newer GNOME versioning convention.

https://github.com/flathub-infra/flatpak-external-data-checker/pull/453

All the *mm use the older convention that an odd minor version indicates an unstable release. Configure all these modules accordingly.