### PR TITLE
Update runtime to 50

### DIFF
--- a/gtkmm.json
+++ b/gtkmm.json
@@ -3,8 +3,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://download.gnome.org/sources/gtkmm/4.20/gtkmm-4.20.0.tar.xz",
-            "sha256": "daad9bf9b70f90975f91781fc7a656c923a91374261f576c883cd3aebd59c833",
+            "url": "https://download.gnome.org/sources/gtkmm/4.22/gtkmm-4.22.0.tar.xz",
+            "sha256": "2e8a21b4b0725f620e33aaee0cd343ed121b533275b632896619b1c89e96de67",
             "x-checker-data": {
                 "type": "gnome",
                 "name": "gtkmm",
@@ -64,8 +64,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/glibmm/2.86/glibmm-2.86.0.tar.xz",
-                    "sha256": "39c0e9f6da046d679390774efdb9ad564436236736dc2f7825e614b2d4087826",
+                    "url": "https://download.gnome.org/sources/glibmm/2.88/glibmm-2.88.0.tar.xz",
+                    "sha256": "a6549da3a6c43de83b8717dae5413c57a60d92f6ecc624615c612d0bb0ad0fe2",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "glibmm",

--- a/org.pulseaudio.pavucontrol.yaml
+++ b/org.pulseaudio.pavucontrol.yaml
@@ -1,6 +1,6 @@
 app-id: org.pulseaudio.pavucontrol
 runtime: org.gnome.Platform
-runtime-version: '49'
+runtime-version: '50'
 sdk: org.gnome.Sdk
 command: pavucontrol
 finish-args:

--- a/screenshots.patch
+++ b/screenshots.patch
@@ -1,8 +1,8 @@
 diff --git a/src/org.pulseaudio.pavucontrol.metainfo.xml.in b/src/org.pulseaudio.pavucontrol.metainfo.xml.in
-index bd63f21..7e98aaa 100644
+index bd63f21..d4db41a 100644
 --- a/src/org.pulseaudio.pavucontrol.metainfo.xml.in
 +++ b/src/org.pulseaudio.pavucontrol.metainfo.xml.in
-@@ -19,23 +19,23 @@
+@@ -19,26 +19,39 @@
    <screenshots>
      <screenshot type="default">
        <caption>The “Playback” tab</caption>
@@ -31,3 +31,32 @@ index bd63f21..7e98aaa 100644
      </screenshot>
    </screenshots>
    <releases>
++
++    <release version="6.2" date="2025-09-17">
++      <description>
++        <ul>
++          <li>A number of translation updates.</li>
++          <li>Add a checkbox to disable unavailable profiles.</li>
++          <li>Avoid inhibiting monitor source suspend.</li>
++          <li>Fix peak decay when monitor is suspended.</li>
++          <li>Add a build option to disable audio feedback.</li>
++        </ul>
++      </description>
++    </release>
++
+     <release version="6.1" date="2024-08-01">
+       <description>
+         <ul>
+@@ -94,7 +107,8 @@
+   <content_rating type="oars-1.1"/>
+   <metadata_license>CC0-1.0</metadata_license>
+   <project_license>GPL-2.0+</project_license>
+-  <url type="homepage">https://freedesktop.org/software/pulseaudio/pavucontrol/</url>
++  <url type="homepage">https://www.freedesktop.org/software/pulseaudio/pavucontrol/</url>
+   <url type="bugtracker">https://gitlab.freedesktop.org/pulseaudio/pavucontrol/issues</url>
++  <url type="vcs-browser">https://gitlab.freedesktop.org/pulseaudio/pavucontrol</url>
+   <update_contact>https://gitlab.freedesktop.org/pulseaudio/pavucontrol/issues/new</update_contact>
+ </component>
+--
+libgit2 1.7.2
+


### PR DESCRIPTION
- Update the runtime version to 50
- Update dependencies via FEDC
- Add missing release information as a patch
- Remove the empty .gitmodules file

See also: https://gitlab.freedesktop.org/pulseaudio/pavucontrol/-/merge_requests/109/